### PR TITLE
Support restir in NRC

### DIFF
--- a/neural_radiance_caching/gpu_kernels/optix_pathtracing_kernels.cu
+++ b/neural_radiance_caching/gpu_kernels/optix_pathtracing_kernels.cu
@@ -90,7 +90,561 @@ CUDA_DEVICE_FUNCTION CUDA_INLINE float3 performNextEventEstimation(
     return ret;
 }
 
-template <bool useNRC>
+
+
+static constexpr bool useMIS_RIS = true;
+
+
+
+template <bool withTemporalRIS, bool useUnbiasedEstimator>
+CUDA_DEVICE_FUNCTION CUDA_INLINE void performInitialAndTemporalRIS() {
+    static_assert(withTemporalRIS || !useUnbiasedEstimator, "Invalid combination.");
+
+    int2 launchIndex = make_int2(optixGetLaunchIndex().x, optixGetLaunchIndex().y);
+
+    uint32_t curBufIdx = plp.f->bufferIndex;
+
+    GBuffer2 gBuffer2 = plp.s->GBuffer2[curBufIdx].read(launchIndex);
+    uint32_t materialSlot = gBuffer2.materialSlot;
+
+    if (materialSlot == 0xFFFFFFFF)
+        return;
+
+    GBuffer0 gBuffer0 = plp.s->GBuffer0[curBufIdx].read(launchIndex);
+    GBuffer1 gBuffer1 = plp.s->GBuffer1[curBufIdx].read(launchIndex);
+    float3 positionInWorld = gBuffer0.positionInWorld;
+    float3 shadingNormalInWorld = gBuffer1.normalInWorld;
+    float2 texCoord = make_float2(gBuffer0.texCoord_x, gBuffer1.texCoord_y);
+
+    PCG32RNG rng = plp.s->rngBuffer.read(launchIndex);
+
+    const MaterialData &mat = plp.s->materialDataBuffer[materialSlot];
+
+    // TODO?: Use true geometric normal.
+    float3 geometricNormalInWorld = shadingNormalInWorld;
+    float3 vOut = plp.f->camera.position - positionInWorld;
+    float frontHit = dot(vOut, geometricNormalInWorld) >= 0.0f ? 1.0f : -1.0f;
+
+    BSDF bsdf;
+    bsdf.setup(mat, texCoord);
+    ReferenceFrame shadingFrame(shadingNormalInWorld);
+    positionInWorld = offsetRayOriginNaive(positionInWorld, frontHit * geometricNormalInWorld);
+    float dist = length(vOut);
+    vOut /= dist;
+    float3 vOutLocal = shadingFrame.toLocal(vOut);
+
+    uint32_t curResIndex = plp.currentReservoirIndex;
+    Reservoir<LightSample> reservoir;
+    reservoir.initialize();
+
+    // JP: Unshadowed ContributionをターゲットPDFとしてStreaming RISを実行。
+    // EN: Perform streaming RIS with unshadowed contribution as the target PDF.
+    float selectedTargetDensity = 0.0f;
+    uint32_t numCandidates = 1 << plp.f->log2NumCandidateSamples;
+    for (int i = 0; i < numCandidates; ++i) {
+        // JP: 環境光テクスチャーが設定されている場合は一定の確率でサンプルする。
+        //     ダイバージェンスを抑えるために、ループの最初とそれ以外で環境光かそれ以外のサンプリングを分ける。
+        // EN: Sample an environmental light texture with a fixed probability if it is set.
+        //     Separate sampling from the environmental light and the others to
+        //     the beginning of the loop and the rest to avoid divergence.
+        float ul = rng.getFloat0cTo1o();
+        float probToSampleCurLightType = 1.0f;
+        bool sampleEnvLight = false;
+        if (plp.s->envLightTexture && plp.f->enableEnvLight) {
+            if (plp.s->lightInstDist.integral() > 0.0f) {
+                float prob = min(max(probToSampleEnvLight * numCandidates - i, 0.0f), 1.0f);
+                if (ul < prob) {
+                    probToSampleCurLightType = probToSampleEnvLight;
+                    ul = ul / prob;
+                    sampleEnvLight = true;
+                }
+                else {
+                    probToSampleCurLightType = 1.0f - probToSampleEnvLight;
+                    ul = (ul - prob) / (1 - prob);
+                }
+            }
+            else {
+                sampleEnvLight = true;
+            }
+        }
+
+        // JP: 候補サンプルを生成して、ターゲットPDFを計算する。
+        //     ターゲットPDFは正規化されていなくても良い。
+        // EN: Generate a candidate sample then calculate the target PDF for it.
+        //     Target PDF doesn't require to be normalized.
+        LightSample lightSample;
+        float probDensity;
+        sampleLight<false>(
+            positionInWorld,
+            ul, sampleEnvLight, rng.getFloat0cTo1o(), rng.getFloat0cTo1o(),
+            &lightSample, &probDensity);
+        float3 cont = performDirectLighting<PathTracingRayType, false>(
+            positionInWorld, vOutLocal, shadingFrame, bsdf,
+            lightSample);
+        probDensity *= probToSampleCurLightType;
+        float targetDensity = convertToWeight(cont);
+
+        // JP: 候補サンプル生成用のPDFとターゲットPDFは異なるためサンプルにはウェイトがかかる。
+        // EN: The sample has a weight since the PDF to generate the candidate sample and the target PDF are
+        //     different.
+        float weight = targetDensity / probDensity;
+        if (reservoir.update(lightSample, weight, rng.getFloat0cTo1o()))
+            selectedTargetDensity = targetDensity;
+    }
+
+    // JP: 現在のサンプルが生き残る確率密度の逆数の推定値を計算する。
+    // EN: Calculate the estimate of the reciprocal of the probability density that the current sample survives.
+    float recPDFEstimate = reservoir.getSumWeights() / (selectedTargetDensity * reservoir.getStreamLength());
+    if (!isfinite(recPDFEstimate)) {
+        recPDFEstimate = 0.0f;
+        selectedTargetDensity = 0.0f;
+    }
+
+    // JP: サンプルが遮蔽されていて寄与を持たない場合に、隣接ピクセルにサンプルが伝播しないよう、
+    //     Reservoirのウェイトをゼロにする。
+    // EN: Set the reservoir's weight to zero so that the occluded sample which has no contribution
+    //     will not propagate to neighboring pixels.
+    if (plp.f->reuseVisibility && selectedTargetDensity > 0.0f) {
+        if (!evaluateVisibility<PathTracingRayType>(positionInWorld, reservoir.getSample())) {
+            recPDFEstimate = 0.0f;
+            selectedTargetDensity = 0.0f;
+        }
+    }
+
+    if constexpr (withTemporalRIS) {
+        uint32_t prevBufIdx = (curBufIdx + 1) % 2;
+        uint32_t prevResIndex = (curResIndex + 1) % 2;
+
+        bool neighborIsSelected;
+        if constexpr (useUnbiasedEstimator)
+            neighborIsSelected = false;
+        else
+            (void)neighborIsSelected;
+        uint32_t selfStreamLength = reservoir.getStreamLength();
+        if (recPDFEstimate == 0.0f)
+            reservoir.initialize();
+        uint32_t combinedStreamLength = selfStreamLength;
+        uint32_t maxPrevStreamLength = 20 * selfStreamLength;
+
+        float2 motionVector = gBuffer2.motionVector;
+        int2 nbCoord = make_int2(launchIndex.x + 0.5f - motionVector.x,
+                                 launchIndex.y + 0.5f - motionVector.y);
+
+        // JP: 隣接ピクセルのジオメトリ・マテリアルがあまりに異なる場合に候補サンプルを再利用すると
+        //     バイアスが増えてしまうため、そのようなピクセルは棄却する。
+        // EN: Reusing candidates from neighboring pixels with substantially different geometry/material
+        //     leads to increased bias. Reject such a pixel.
+        bool acceptedNeighbor = testNeighbor<!useUnbiasedEstimator>(prevBufIdx, nbCoord, dist, shadingNormalInWorld);
+        if (acceptedNeighbor) {
+            const Reservoir<LightSample> /*&*/neighbor = plp.s->reservoirBuffer[prevResIndex][nbCoord];
+            const ReservoirInfo neighborInfo = plp.s->reservoirInfoBuffer[prevResIndex].read(nbCoord);
+
+            // JP: 隣接ピクセルが持つ候補サンプルの「現在の」ピクセルにおける確率密度を計算する。
+            // EN: Calculate the probability density at the "current" pixel of the candidate sample
+            //     the neighboring pixel holds.
+            // TODO: アニメーションやジッタリングがある場合には前フレームの対応ピクセルのターゲットPDFは
+            //       変わってしまっているはず。この場合にはUnbiasedにするにはもうちょっと工夫がいる？
+            LightSample nbLightSample = neighbor.getSample();
+            float3 cont = performDirectLighting<PathTracingRayType, false>(
+                positionInWorld, vOutLocal, shadingFrame, bsdf, nbLightSample);
+            float targetDensity = convertToWeight(cont);
+
+            // JP: 際限なく過去フレームで得たサンプルがウェイトを増やさないように、
+            //     前フレームのストリーム長を、現在フレームのReservoirに対して20倍までに制限する。
+            // EN: Limit the stream length of the previous frame by 20 times of that of the current frame
+            //     in order to avoid a sample obtained in the past getting an unlimited weight.
+            uint32_t nbStreamLength = min(neighbor.getStreamLength(), maxPrevStreamLength);
+            float weight = targetDensity * neighborInfo.recPDFEstimate * nbStreamLength;
+            if (reservoir.update(nbLightSample, weight, rng.getFloat0cTo1o())) {
+                selectedTargetDensity = targetDensity;
+                if constexpr (useUnbiasedEstimator)
+                    neighborIsSelected = true;
+            }
+
+            combinedStreamLength += nbStreamLength;
+        }
+        reservoir.setStreamLength(combinedStreamLength);
+
+        float weightForEstimate;
+        if constexpr (useUnbiasedEstimator) {
+            // JP: 推定関数をunbiasedとするための、生き残ったサンプルのウェイトを計算する。
+            //     ここではReservoirの結合時とは逆に、サンプルは生き残った1つだが、
+            //     ターゲットPDFは隣接ピクセルのものを評価する。
+            // EN: Compute a weight for the survived sample to make the estimator unbiased.
+            //     In contrast to the case where we combine reservoirs, the sample is only one survived and
+            //     Evaluate target PDFs at the neighboring pixels here.
+            LightSample selectedLightSample = reservoir.getSample();
+
+            float numWeight;
+            float denomWeight;
+
+            // JP: まずは現在のピクセルのターゲットPDFに対応する量を計算。
+            // EN: First, calculate a quantity corresponding to the current pixel's target PDF.
+            {
+                float3 cont = performDirectLighting<PathTracingRayType, false>(
+                    positionInWorld, vOutLocal, shadingFrame, bsdf, selectedLightSample);
+                float targetDensityForSelf = convertToWeight(cont);
+                if constexpr (useMIS_RIS) {
+                    numWeight = targetDensityForSelf;
+                    denomWeight = targetDensityForSelf * selfStreamLength;
+                }
+                else {
+                    numWeight = 1.0f;
+                    denomWeight = 0.0f;
+                    if (targetDensityForSelf > 0.0f)
+                        denomWeight = selfStreamLength;
+                }
+            }
+
+            // JP: 続いて隣接ピクセルのターゲットPDFに対応する量を計算。
+            // EN: Next, calculate a quantity corresponding to the neighboring pixel's target PDF.
+            if (acceptedNeighbor) {
+                GBuffer2 nbGBuffer2 = plp.s->GBuffer2[prevBufIdx].read(nbCoord);
+                uint32_t nbMaterialSlot = nbGBuffer2.materialSlot;
+                if (nbMaterialSlot != 0xFFFFFFFF) {
+                    GBuffer0 nbGBuffer0 = plp.s->GBuffer0[prevBufIdx].read(nbCoord);
+                    GBuffer1 nbGBuffer1 = plp.s->GBuffer1[prevBufIdx].read(nbCoord);
+                    float3 nbPositionInWorld = nbGBuffer0.positionInWorld;
+                    float3 nbShadingNormalInWorld = nbGBuffer1.normalInWorld;
+                    float2 nbTexCoord = make_float2(nbGBuffer0.texCoord_x, nbGBuffer1.texCoord_y);
+
+                    const MaterialData &nbMat = plp.s->materialDataBuffer[nbMaterialSlot];
+
+                    // TODO?: Use true geometric normal.
+                    float3 nbGeometricNormalInWorld = nbShadingNormalInWorld;
+                    float3 nbVOut = plp.f->camera.position - nbPositionInWorld;
+                    float nbFrontHit = dot(nbVOut, nbGeometricNormalInWorld) >= 0.0f ? 1.0f : -1.0f;
+
+                    BSDF nbBsdf;
+                    nbBsdf.setup(nbMat, nbTexCoord);
+                    ReferenceFrame nbShadingFrame(nbShadingNormalInWorld);
+                    nbPositionInWorld = offsetRayOriginNaive(nbPositionInWorld, nbFrontHit * nbGeometricNormalInWorld);
+                    float nbDist = length(nbVOut);
+                    nbVOut /= nbDist;
+                    float3 nbVOutLocal = nbShadingFrame.toLocal(nbVOut);
+
+                    const Reservoir<LightSample> /*&*/neighbor = plp.s->reservoirBuffer[prevResIndex][nbCoord];
+
+                    // JP: 際限なく過去フレームのウェイトが高まってしまうのを防ぐため、
+                    //     Temporal Reuseでは前フレームのストリーム長を現在のピクセルの20倍に制限する。
+                    // EN: To prevent the weight for previous frames to grow unlimitedly,
+                    //     limit the previous frame's weight by 20x of the current pixel's one.
+                    float3 cont = performDirectLighting<PathTracingRayType, false>(
+                        nbPositionInWorld, nbVOutLocal, nbShadingFrame, nbBsdf, selectedLightSample);
+                    float nbTargetDensity = convertToWeight(cont);
+                    uint32_t nbStreamLength = min(neighbor.getStreamLength(), maxPrevStreamLength);
+                    if constexpr (useMIS_RIS) {
+                        denomWeight += nbTargetDensity * nbStreamLength;
+                        if (neighborIsSelected)
+                            numWeight = nbTargetDensity;
+                    }
+                    else {
+                        if (nbTargetDensity > 0.0f)
+                            denomWeight += nbStreamLength;
+                    }
+                }
+            }
+
+            weightForEstimate = numWeight / denomWeight;
+        }
+        else {
+            weightForEstimate = 1.0f / reservoir.getStreamLength();
+        }
+
+        // JP: 現在のサンプルが生き残る確率密度の逆数の推定値を計算する。
+        // EN: Calculate the estimate of the reciprocal of the probability density that the current sample survives.
+        recPDFEstimate = weightForEstimate * reservoir.getSumWeights() / selectedTargetDensity;
+        if (!isfinite(recPDFEstimate)) {
+            recPDFEstimate = 0.0f;
+            selectedTargetDensity = 0.0f;
+        }
+    }
+
+    ReservoirInfo reservoirInfo;
+    reservoirInfo.recPDFEstimate = recPDFEstimate;
+    reservoirInfo.targetDensity = selectedTargetDensity;
+
+    plp.s->rngBuffer.write(launchIndex, rng);
+    plp.s->reservoirBuffer[curResIndex][launchIndex] = reservoir;
+    plp.s->reservoirInfoBuffer[curResIndex].write(launchIndex, reservoirInfo);
+}
+
+CUDA_DEVICE_KERNEL void RT_RG_NAME(performInitialRIS)() {
+    performInitialAndTemporalRIS<false, false>();
+}
+
+CUDA_DEVICE_KERNEL void RT_RG_NAME(performInitialAndTemporalRISBiased)() {
+    performInitialAndTemporalRIS<true, false>();
+}
+
+CUDA_DEVICE_KERNEL void RT_RG_NAME(performInitialAndTemporalRISUnbiased)() {
+    performInitialAndTemporalRIS<true, true>();
+}
+
+
+
+template <bool useUnbiasedEstimator>
+CUDA_DEVICE_FUNCTION CUDA_INLINE void performSpatialRIS() {
+    int2 launchIndex = make_int2(optixGetLaunchIndex().x, optixGetLaunchIndex().y);
+
+    uint32_t bufIdx = plp.f->bufferIndex;
+
+    GBuffer2 gBuffer2 = plp.s->GBuffer2[bufIdx].read(launchIndex);
+    uint32_t materialSlot = gBuffer2.materialSlot;
+
+    if (materialSlot == 0xFFFFFFFF)
+        return;
+
+    GBuffer0 gBuffer0 = plp.s->GBuffer0[bufIdx].read(launchIndex);
+    GBuffer1 gBuffer1 = plp.s->GBuffer1[bufIdx].read(launchIndex);
+    float3 positionInWorld = gBuffer0.positionInWorld;
+    float3 shadingNormalInWorld = gBuffer1.normalInWorld;
+    float2 texCoord = make_float2(gBuffer0.texCoord_x, gBuffer1.texCoord_y);
+
+    PCG32RNG rng = plp.s->rngBuffer.read(launchIndex);
+
+    const MaterialData &mat = plp.s->materialDataBuffer[materialSlot];
+
+    // TODO?: Use true geometric normal.
+    float3 geometricNormalInWorld = shadingNormalInWorld;
+    float3 vOut = plp.f->camera.position - positionInWorld;
+    float frontHit = dot(vOut, geometricNormalInWorld) >= 0.0f ? 1.0f : -1.0f;
+
+    BSDF bsdf;
+    bsdf.setup(mat, texCoord);
+    ReferenceFrame shadingFrame(shadingNormalInWorld);
+    positionInWorld = offsetRayOriginNaive(positionInWorld, frontHit * geometricNormalInWorld);
+    float dist = length(vOut);
+    vOut /= dist;
+    float3 vOutLocal = shadingFrame.toLocal(vOut);
+
+    uint32_t srcResIndex = plp.currentReservoirIndex;
+    uint32_t dstResIndex = (srcResIndex + 1) % 2;
+
+    Reservoir<LightSample> combinedReservoir;
+    combinedReservoir.initialize();
+    float selectedTargetDensity = 0.0f;
+    int32_t selectedNeighborIndex;
+    if constexpr (useUnbiasedEstimator)
+        selectedNeighborIndex = -1;
+    else
+        (void)selectedNeighborIndex;
+
+    // JP: まず現在のピクセルのReservoirを結合する。
+    // EN: First combine the reservoir for the current pixel.
+    const Reservoir<LightSample> /*&*/self = plp.s->reservoirBuffer[srcResIndex][launchIndex];
+    const ReservoirInfo selfResInfo = plp.s->reservoirInfoBuffer[srcResIndex].read(launchIndex);
+    if (selfResInfo.recPDFEstimate > 0.0f) {
+        combinedReservoir = self;
+        selectedTargetDensity = selfResInfo.targetDensity;
+    }
+    uint32_t combinedStreamLength = self.getStreamLength();
+
+    for (int nIdx = 0; nIdx < plp.f->numSpatialNeighbors; ++nIdx) {
+        // JP: 周辺ピクセルの座標をランダムに決定。
+        // EN: Randomly determine the coordinates of a neighboring pixel.
+        float radius = plp.f->spatialNeighborRadius;
+        float deltaX, deltaY;
+        if (plp.f->useLowDiscrepancyNeighbors) {
+            float2 delta = plp.s->spatialNeighborDeltas[(plp.spatialNeighborBaseIndex + nIdx) % 1024];
+            deltaX = radius * delta.x;
+            deltaY = radius * delta.y;
+        }
+        else {
+            radius *= std::sqrt(rng.getFloat0cTo1o());
+            float angle = 2 * Pi * rng.getFloat0cTo1o();
+            deltaX = radius * std::cos(angle);
+            deltaY = radius * std::sin(angle);
+        }
+        int2 nbCoord = make_int2(launchIndex.x + 0.5f + deltaX,
+                                    launchIndex.y + 0.5f + deltaY);
+
+        // JP: 隣接ピクセルのジオメトリ・マテリアルがあまりに異なる場合に候補サンプルを再利用すると
+        //     バイアスが増えてしまうため、そのようなピクセルは棄却する。
+        // EN: Reusing candidates from neighboring pixels with substantially different geometry/material
+        //     leads to increased bias. Reject such a pixel.
+        bool acceptedNeighbor = testNeighbor<!useUnbiasedEstimator>(bufIdx, nbCoord, dist, shadingNormalInWorld);
+        acceptedNeighbor &= nbCoord.x != launchIndex.x || nbCoord.y != launchIndex.y;
+        if (acceptedNeighbor) {
+            const Reservoir<LightSample> /*&*/neighbor = plp.s->reservoirBuffer[srcResIndex][nbCoord];
+            const ReservoirInfo neighborInfo = plp.s->reservoirInfoBuffer[srcResIndex].read(nbCoord);
+
+            // JP: 隣接ピクセルが持つ候補サンプルの「現在の」ピクセルにおける確率密度を計算する。
+            // EN: Calculate the probability density at the "current" pixel of the candidate sample
+            //     the neighboring pixel holds.
+            LightSample nbLightSample = neighbor.getSample();
+            float3 cont = performDirectLighting<PathTracingRayType, false>(
+                positionInWorld, vOutLocal, shadingFrame, bsdf, nbLightSample);
+            float targetDensity = convertToWeight(cont);
+
+            // JP: 隣接ピクセルと現在のピクセルではターゲットPDFが異なるためサンプルはウェイトを持つ。
+            // EN: The sample has a weight since the target PDFs of the neighboring pixel and the current
+            //     are the different.
+            uint32_t nbStreamLength = neighbor.getStreamLength();
+            float weight = targetDensity * neighborInfo.recPDFEstimate * nbStreamLength;
+            if (combinedReservoir.update(nbLightSample, weight, rng.getFloat0cTo1o())) {
+                selectedTargetDensity = targetDensity;
+                if constexpr (useUnbiasedEstimator)
+                    selectedNeighborIndex = nIdx;
+            }
+
+            combinedStreamLength += nbStreamLength;
+        }
+    }
+    combinedReservoir.setStreamLength(combinedStreamLength);
+
+    float weightForEstimate = 0.0f;
+    if constexpr (useUnbiasedEstimator) {
+        // printf("unbiased restir rendering!\n");
+        if (selectedTargetDensity > 0.0f) {
+            // JP: 推定関数をunbiasedとするための、生き残ったサンプルのウェイトを計算する。
+            //     ここではReservoirの結合時とは逆に、サンプルは生き残った1つだが、
+            //     ターゲットPDFは隣接ピクセルのものを評価する。
+            // EN: Compute a weight for the survived sample to make the estimator unbiased.
+            //     In contrast to the case where we combine reservoirs, the sample is only one survived and
+            //     Evaluate target PDFs at the neighboring pixels here.
+            LightSample selectedLightSample = combinedReservoir.getSample();
+
+            float numWeight;
+            float denomWeight;
+
+            // JP: まずは現在のピクセルのターゲットPDFに対応する量を計算。
+            // EN: First, calculate a quantity corresponding to the current pixel's target PDF.
+            bool visibility = true;
+            {
+                float3 cont;
+                if (plp.f->reuseVisibility)
+                    cont = performDirectLighting<PathTracingRayType, true>(
+                        positionInWorld, vOutLocal, shadingFrame, bsdf, selectedLightSample);
+                else
+                    cont = performDirectLighting<PathTracingRayType, false>(
+                        positionInWorld, vOutLocal, shadingFrame, bsdf, selectedLightSample);
+                float targetDensityForSelf = convertToWeight(cont);
+                if (plp.f->reuseVisibility)
+                    visibility = targetDensityForSelf > 0.0f;
+                if constexpr (useMIS_RIS) {
+                    numWeight = targetDensityForSelf;
+                    denomWeight = targetDensityForSelf * self.getStreamLength();
+                }
+                else {
+                    numWeight = 1.0f;
+                    denomWeight = 0.0f;
+                    if (targetDensityForSelf > 0.0f)
+                        denomWeight = self.getStreamLength();
+                }
+            }
+
+            // JP: 続いて隣接ピクセルのターゲットPDFに対応する量を計算。
+            // EN: Next, calculate quantities corresponding to the neighboring pixels' target PDFs.
+            for (int nIdx = 0; nIdx < plp.f->numSpatialNeighbors; ++nIdx) {
+                float radius = plp.f->spatialNeighborRadius;
+                float deltaX, deltaY;
+                if (plp.f->useLowDiscrepancyNeighbors) {
+                    float2 delta = plp.s->spatialNeighborDeltas[(plp.spatialNeighborBaseIndex + nIdx) % 1024];
+                    deltaX = radius * delta.x;
+                    deltaY = radius * delta.y;
+                }
+                else {
+                    radius *= std::sqrt(rng.getFloat0cTo1o());
+                    float angle = 2 * Pi * rng.getFloat0cTo1o();
+                    deltaX = radius * std::cos(angle);
+                    deltaY = radius * std::sin(angle);
+                }
+                int2 nbCoord = make_int2(launchIndex.x + 0.5f + deltaX,
+                                         launchIndex.y + 0.5f + deltaY);
+
+                bool acceptedNeighbor =
+                    nbCoord.x >= 0 && nbCoord.x < plp.s->imageSize.x &&
+                    nbCoord.y >= 0 && nbCoord.y < plp.s->imageSize.y;
+                acceptedNeighbor &= nbCoord.x != launchIndex.x || nbCoord.y != launchIndex.y;
+                if (acceptedNeighbor) {
+                    GBuffer2 nbGBuffer2 = plp.s->GBuffer2[bufIdx].read(nbCoord);
+
+                    uint32_t nbMaterialSlot = nbGBuffer2.materialSlot;
+                    if (nbMaterialSlot == 0xFFFFFFFF)
+                        continue;
+
+                    GBuffer0 nbGBuffer0 = plp.s->GBuffer0[bufIdx].read(nbCoord);
+                    GBuffer1 nbGBuffer1 = plp.s->GBuffer1[bufIdx].read(nbCoord);
+                    float3 nbPositionInWorld = nbGBuffer0.positionInWorld;
+                    float3 nbShadingNormalInWorld = nbGBuffer1.normalInWorld;
+                    float2 nbTexCoord = make_float2(nbGBuffer0.texCoord_x, nbGBuffer1.texCoord_y);
+
+                    const MaterialData &nbMat = plp.s->materialDataBuffer[nbMaterialSlot];
+
+                    // TODO?: Use true geometric normal.
+                    float3 nbGeometricNormalInWorld = nbShadingNormalInWorld;
+                    float3 nbVOut = plp.f->camera.position - nbPositionInWorld;
+                    float nbFrontHit = dot(nbVOut, nbGeometricNormalInWorld) >= 0.0f ? 1.0f : -1.0f;
+
+                    BSDF nbBsdf;
+                    nbBsdf.setup(nbMat, nbTexCoord);
+                    ReferenceFrame nbShadingFrame(nbShadingNormalInWorld);
+                    nbPositionInWorld = offsetRayOriginNaive(nbPositionInWorld, nbFrontHit * nbGeometricNormalInWorld);
+                    float nbDist = length(nbVOut);
+                    nbVOut /= nbDist;
+                    float3 nbVOutLocal = nbShadingFrame.toLocal(nbVOut);
+
+                    const Reservoir<LightSample> /*&*/neighbor = plp.s->reservoirBuffer[srcResIndex][nbCoord];
+
+                    // TODO: ウェイトの条件さえ満たしていれば、MISウェイト計算にはVisibilityはなくても良い？
+                    //       要検討。
+                    float3 cont;
+                    if (plp.f->reuseVisibility)
+                        cont = performDirectLighting<PathTracingRayType, true>(
+                            nbPositionInWorld, nbVOutLocal, nbShadingFrame, nbBsdf, selectedLightSample);
+                    else
+                        cont = performDirectLighting<PathTracingRayType, false>(
+                            nbPositionInWorld, nbVOutLocal, nbShadingFrame, nbBsdf, selectedLightSample);
+                    float nbTargetDensity = convertToWeight(cont);
+                    uint32_t nbStreamLength = neighbor.getStreamLength();
+                    if constexpr (useMIS_RIS) {
+                        denomWeight += nbTargetDensity * nbStreamLength;
+                        if (nIdx == selectedNeighborIndex)
+                            numWeight = nbTargetDensity;
+                    }
+                    else {
+                        if (nbTargetDensity > 0.0f)
+                            denomWeight += nbStreamLength;
+                    }
+                }
+            }
+
+            weightForEstimate = numWeight / denomWeight;
+            if (plp.f->reuseVisibility && !visibility)
+                weightForEstimate = 0.0f;
+        }
+    }
+    else {
+        weightForEstimate = 1.0f / combinedReservoir.getStreamLength();
+    }
+
+    // JP: 現在のサンプルが生き残る確率密度の逆数の推定値を計算する。
+    // EN: Calculate the estimate of the reciprocal of the probability density that the current sample survives.
+    ReservoirInfo reservoirInfo;
+    reservoirInfo.recPDFEstimate = weightForEstimate * combinedReservoir.getSumWeights() / selectedTargetDensity;
+    reservoirInfo.targetDensity = selectedTargetDensity;
+    if (!isfinite(reservoirInfo.recPDFEstimate)) {
+        reservoirInfo.recPDFEstimate = 0.0f;
+        reservoirInfo.targetDensity = 0.0f;
+    }
+
+    plp.s->rngBuffer.write(launchIndex, rng);
+    plp.s->reservoirBuffer[dstResIndex][launchIndex] = combinedReservoir;
+    plp.s->reservoirInfoBuffer[dstResIndex].write(launchIndex, reservoirInfo);
+}
+
+CUDA_DEVICE_KERNEL void RT_RG_NAME(performSpatialRISBiased)() {
+    performSpatialRIS<false>();
+}
+
+CUDA_DEVICE_KERNEL void RT_RG_NAME(performSpatialRISUnbiased)() {
+    performSpatialRIS<true>();
+}
+
+
+
+template <bool useNRC, bool useReSTIR>
 CUDA_DEVICE_FUNCTION CUDA_INLINE void pathTrace_raygen_generic() {
     uint2 launchIndex = make_uint2(optixGetLaunchIndex().x, optixGetLaunchIndex().y);
 
@@ -182,10 +736,34 @@ CUDA_DEVICE_FUNCTION CUDA_INLINE void pathTrace_raygen_generic() {
             BSDF bsdf;
             bsdf.setup(mat, texCoord);
 
-            // Next event estimation (explicit light sampling) on the first hit.
-            float3 directContNEE = performNextEventEstimation(
-                positionInWorld, vOutLocal, shadingFrame, bsdf, rng);
-            contribution += alpha * directContNEE;
+
+            float3 directContNEE = make_float3(0.0f);
+            if constexpr (useReSTIR) {
+                uint32_t curResIndex = plp.currentReservoirIndex;
+                const Reservoir<LightSample> /*&*/reservoir = plp.s->reservoirBuffer[curResIndex][launchIndex];
+                const ReservoirInfo reservoirInfo = plp.s->reservoirInfoBuffer[curResIndex].read(launchIndex);
+                // JP: 最終的に残ったサンプルとそのウェイトを使ってシェーディングを実行する。
+                // EN: Perform shading using the sample survived in the end and its weight.
+                const LightSample &lightSample = reservoir.getSample();
+                float recPDFEstimate = reservoirInfo.recPDFEstimate;
+                if (recPDFEstimate > 0 && isfinite(recPDFEstimate)) {
+                    bool visDone = plp.f->reuseVisibility &&
+                        (!plp.f->enableTemporalReuse || (plp.f->enableSpatialReuse && plp.f->useUnbiasedEstimator));
+                    if (visDone)
+                        directContNEE = performDirectLighting<PathTracingRayType, false>(
+                            positionInWorld, vOutLocal, shadingFrame, bsdf, lightSample);
+                    else
+                        directContNEE = performDirectLighting<PathTracingRayType, true>(
+                            positionInWorld, vOutLocal, shadingFrame, bsdf, lightSample);
+                }
+                directContNEE *= recPDFEstimate;
+                contribution += alpha * directContNEE;
+            } else {
+                // Next event estimation (explicit light sampling) on the first hit.
+                directContNEE = performNextEventEstimation(
+                    positionInWorld, vOutLocal, shadingFrame, bsdf, rng);
+                contribution += alpha * directContNEE;
+            }
 
             // generate a next ray.
             float3 vInLocal;
@@ -657,7 +1235,11 @@ CUDA_DEVICE_FUNCTION CUDA_INLINE void pathTrace_miss_generic() {
 
 
 CUDA_DEVICE_KERNEL void RT_RG_NAME(pathTraceBaseline)() {
-    pathTrace_raygen_generic<false>();
+    pathTrace_raygen_generic<false, false>();
+}
+
+CUDA_DEVICE_KERNEL void RT_RG_NAME(pathTraceBaselineReSTIR)() {
+    pathTrace_raygen_generic<false, true>();
 }
 
 CUDA_DEVICE_KERNEL void RT_CH_NAME(pathTraceBaseline)() {
@@ -671,7 +1253,11 @@ CUDA_DEVICE_KERNEL void RT_MS_NAME(pathTraceBaseline)() {
 
 
 CUDA_DEVICE_KERNEL void RT_RG_NAME(pathTraceNRC)() {
-    pathTrace_raygen_generic<true>();
+    pathTrace_raygen_generic<true, false>();
+}
+
+CUDA_DEVICE_KERNEL void RT_RG_NAME(pathTraceNRCReSTIR)() {
+    pathTrace_raygen_generic<true, true>();
 }
 
 CUDA_DEVICE_KERNEL void RT_CH_NAME(pathTraceNRC)() {


### PR DESCRIPTION
I tried to implement ReSTIR in NRC by re-using and merging the code in `./restir` project. ReSTIR is performed by simply replacing the NEE (explicit light sampling) for the first vertex in `pathTrace_raygen_generic()`. However, I'm a total beginner in this field so could have done something wrong. Please correct me if you find any mistakes.

Original NRC result:
![nrc](https://user-images.githubusercontent.com/32335747/230887628-54263c36-cabc-42cf-b697-a6c173214399.png)

NRC + ReSTIR:
![nrc_restir](https://user-images.githubusercontent.com/32335747/230887661-9e80b661-c8c3-4fce-a8a9-78293a89dc00.png)

